### PR TITLE
Fix HTML validation issues by closing the list elements of the localeswitcher

### DIFF
--- a/views/twig/_localeswitcher.twig
+++ b/views/twig/_localeswitcher.twig
@@ -12,5 +12,6 @@
                  )}}">
                  {{ locale.label }}
             </a>
+        </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
Just noticed a small error in the default localeswitcher twig (I guess).

Fix it with this very simple hotfix that just adds the missing </li> ;-)