### PR TITLE
fix localeswitcher for subfolders

### DIFF
--- a/templates/frontend/_localeswitcher.twig
+++ b/templates/frontend/_localeswitcher.twig
@@ -9,7 +9,7 @@
             <a title="{{ locale.label }}" href="{{ newslug ? url(
                 app.request.get('_route'), 
                 app.request.get('_route_params')|merge({_locale: locale.slug, slug: newslug })
-                ) : '/' ~ locale.slug }}">
+                ) : url('homepage', {_locale: locale.slug}) }}">
                 {{ locale.label }}
             </a>
     {% endfor %}


### PR DESCRIPTION
Don't assume that bolt is mounted on the root, use the urlgenerator for homepage link.

Fixes #36

