### PR TITLE
Fix LocalizedMenuBuilder's missing reference to Lib::path

### DIFF
--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -18,6 +18,9 @@ class LocalizedFrontend extends Frontend
                 if($name !== "preview"){
                     $route['path'] = '/{_locale}'.$route['path'];
                     $route['requirements']['_locale'] = "^[a-z]{2}(_[A-Z]{2})?$";
+
+                    // Using the url generator on a 404 response requires a default _locale to be set
+                    $route['defaults']['_locale'] = $this->app['translate.slug'];
                 }
             }
             $routes['homepageredir'] = ['path' => '/', 'defaults' => [ '_controller' => 'controller.frontend:homepageRedirect' ]];

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -30,6 +30,9 @@ class TranslateExtension extends SimpleExtension
         $this->registerTranslateServices($app);
         $this->registerOverrides($app);
         $app->before([$this, 'before']);
+
+        // Set default localeSlug in the event before() is not called, e.g. a 404
+        $this->localeSlug = array_column($this->config['locales'], 'slug')[0];
     }
 
     /**


### PR DESCRIPTION
Fixes LocalizedMenuBuilder's missing reference to Lib::path, by copying bolt's private function `resolveRouteToLink()` and referring to this function instead.

Fixes: #42