### PR TITLE
Clean up and corner case bug fixes

### DIFF
--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -8,7 +8,6 @@ use Bolt\Storage\QuerySet;
 
 class LocaleField extends FieldTypeBase
 {
-
     public function persist(QuerySet $queries, $entity, EntityManager $em = null)
     {
         /*$queries[0]->setParameter('title', 'test1');
@@ -42,5 +41,4 @@ class LocaleField extends FieldTypeBase
     {
         return ['default' => ''];
     }
-
 }

--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -3,7 +3,6 @@
 namespace Bolt\Extension\Animal\Translate\Frontend;
 
 use Bolt\Controller\Frontend;
-use Bolt\Storage\Query\SelectQuery;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -13,11 +12,11 @@ class LocalizedFrontend extends Frontend
     {
         $routes = $this->app['config']->get('routing', []);
 
-        if($this->app['translate.config']['routing_override']){
+        if ($this->app['translate.config']['routing_override']) {
             foreach ($routes as $name => &$route) {
-                if($name !== "preview"){
-                    $route['path'] = '/{_locale}'.$route['path'];
-                    $route['requirements']['_locale'] = "^[a-z]{2}(_[A-Z]{2})?$";
+                if ($name !== 'preview') {
+                    $route['path'] = '/{_locale}' . $route['path'];
+                    $route['requirements']['_locale'] = '^[a-z]{2}(_[A-Z]{2})?$';
 
                     // Using the url generator on a 404 response requires a default _locale to be set
                     $route['defaults']['_locale'] = $this->app['translate.slug'];
@@ -29,7 +28,8 @@ class LocalizedFrontend extends Frontend
         return $routes;
     }
     
-    public function homepageRedirect(Request $request){
+    public function homepageRedirect(Request $request)
+    {
         return $this->app->redirect($this->app['translate.slug']);
     }
     
@@ -52,13 +52,13 @@ class LocalizedFrontend extends Frontend
         $repo = $this->app['storage']->getRepository($contenttype['slug']);
         $qb = $repo->createQueryBuilder();
         $qb->select('slug')
-            ->where($localeSlug.'_slug = ?')
+            ->where($localeSlug . '_slug = ?')
             ->setParameter(0, $slug)
             ->setMaxResults(1);
 
         $result = $qb->execute()->fetch();
 
-        if (is_numeric($slug) || !$this->app['translate.config']['translate_slugs']){
+        if (is_numeric($slug) || !$this->app['translate.config']['translate_slugs']) {
             return parent::record($request, $contenttypeslug, $slug);
         }
 

--- a/src/Frontend/LocalizedMenuBuilder.php
+++ b/src/Frontend/LocalizedMenuBuilder.php
@@ -2,12 +2,12 @@
 
 namespace Bolt\Extension\Animal\Translate\Frontend;
 
-use Bolt\Menu\MenuBuilder;
 use Bolt\Menu\Menu;
+use Bolt\Menu\MenuBuilder;
 
 class LocalizedMenuBuilder extends MenuBuilder
 {
-    private $prefix = "";
+    private $prefix = '';
     
     public function resolve(array $menu)
     {
@@ -16,7 +16,7 @@ class LocalizedMenuBuilder extends MenuBuilder
         $prop->setAccessible(true);
         $this->app = $prop->getValue($this);
         
-        if(isset($this->app['translate.slug'])){
+        if (isset($this->app['translate.slug'])) {
             $this->prefix = $this->app['translate.slug'] . '/';
         }
         
@@ -31,6 +31,7 @@ class LocalizedMenuBuilder extends MenuBuilder
                 $menu[$key]['submenu'] = $this->menuBuilder($item['submenu']);
             }
         }
+
         return $menu;
     }
     
@@ -45,6 +46,7 @@ class LocalizedMenuBuilder extends MenuBuilder
         } elseif (isset($item['path'])) {
             $item = $this->resolvePathToContent($item);
         }
+
         return $item;
     }
    
@@ -94,7 +96,6 @@ class LocalizedMenuBuilder extends MenuBuilder
 
         // Get a copy of the path minus trailing/leading slash
         $path = ltrim(rtrim($item['path'], '/'), '/');
-
 
         // Pre-set our link in case the match() throws an exception
         $item['link'] = $this->app['resources']->getUrl('root') . $this->prefix . $path;

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -14,7 +14,7 @@ class FieldProvider implements ServiceProviderInterface
         $app['storage.typemap'] = array_merge(
             $app['storage.typemap'],
             [
-                'locale' => LocaleField::class
+                'locale' => LocaleField::class,
             ]
         );
 
@@ -28,7 +28,6 @@ class FieldProvider implements ServiceProviderInterface
                 }
             )
         );
-
     }
 
     /**

--- a/src/Storage/ContentTypeTable.php
+++ b/src/Storage/ContentTypeTable.php
@@ -13,8 +13,8 @@ class ContentTypeTable extends ContentType
      * ContentTypeTable constructor
      *
      * @param AbstractPlatform $platform
-     * @param string $tablePrefix
-     * @param array $config
+     * @param string           $tablePrefix
+     * @param array            $config
      */
     public function __construct(AbstractPlatform $platform, $tablePrefix, array $config)
     {
@@ -30,8 +30,8 @@ class ContentTypeTable extends ContentType
     {
         parent::addColumns();
         foreach ($this->config['locales'] as $locale) {
-            $this->table->addColumn($locale['slug'].'_slug', 'string', array('length' => 256, 'default' => ''));
-            $this->table->addColumn($locale['slug'].'_data', 'text', array('notnull' => false));
+            $this->table->addColumn($locale['slug'] . '_slug', 'string', ['length' => 256, 'default' => '']);
+            $this->table->addColumn($locale['slug'] . '_data', 'text', ['notnull' => false]);
         }
     }
 
@@ -42,7 +42,7 @@ class ContentTypeTable extends ContentType
     {
         parent::addIndexes();
         foreach ($this->config['locales'] as $locale) {
-            $this->table->addIndex([$locale['slug'].'_slug']);
+            $this->table->addIndex([$locale['slug'] . '_slug']);
         }
     }
 }

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -2,8 +2,8 @@
 
 namespace Bolt\Extension\Animal\Translate\Storage;
 
-use Bolt\Legacy\Storage;
 use Bolt\Legacy\Content;
+use Bolt\Legacy\Storage;
 use Bolt\Storage\Field\Collection\RepeatingFieldCollection;
 
 class Legacy extends Storage
@@ -20,8 +20,8 @@ class Legacy extends Storage
         $this->localeValues = $values;
         
         $localeSlug = $app['translate.slug'];
-        if(isset($values[$localeSlug.'_data'])){
-            $localeData = json_decode($values[$localeSlug.'_data'], true);
+        if (isset($values[$localeSlug . '_data'])) {
+            $localeData = json_decode($values[$localeSlug . '_data'], true);
             foreach ($localeData as $key => $value) {
                 $values[$key] = is_array($value) ? json_encode($value) : $value;
             }
@@ -43,6 +43,7 @@ class Legacy extends Storage
         } else {
             $content = new Content($app, $contenttype, $values);
         }
+
         return $content;
     }
 
@@ -50,37 +51,38 @@ class Legacy extends Storage
     {
         $result = parent::getContent($textquery, $parameters, $pager, $whereparameters);
 
-        if($result){
+        if ($result) {
             $reflection = new \ReflectionClass($this);
             $prop = $reflection->getParentClass()->getProperty('app');
             $prop->setAccessible(true);
             $app = $prop->getValue($this);
 
-            if(is_array($result)){
+            if (is_array($result)) {
                 foreach ($result as &$record) {
                     $this->repeaterHydrate($record, $app);
                 }
-            }else{
+            } else {
                 $this->repeaterHydrate($result, $app);
             }
         }
+
         return $result;
     }
 
-    private function repeaterHydrate($record, $app) {
-
+    private function repeaterHydrate($record, $app)
+    {
         $contentTypeName = $record->contenttype['slug'];
 
-        $contentType = $app['config']->get('contenttypes/'.$contentTypeName);
+        $contentType = $app['config']->get('contenttypes/' . $contentTypeName);
         
         $values = $this->localeValues;
         $localeSlug = $app['translate.slug'];
 
-        if(isset($values[$localeSlug.'_data'])){
-            $localeData = json_decode($values[$localeSlug.'_data'], true);
+        if (isset($values[$localeSlug . '_data'])) {
+            $localeData = json_decode($values[$localeSlug . '_data'], true);
             
             foreach ($localeData as $key => $value) {
-                if ($contentType['fields'][$key]['type'] === 'repeater'){
+                if ($contentType['fields'][$key]['type'] === 'repeater') {
                     // Hackish fix until #5533 gets fixed, after that L85-88 can be replaced by L89
                     $originalMapping[$key]['fields'] = $contentType['fields'][$key]['fields'];
                     $originalMapping[$key]['type'] = 'repeater';

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -238,17 +238,16 @@ class TranslateExtension extends SimpleExtension
     public function postSave(StorageEvent $event)
     {
         $subject = $event->getSubject();
-        if (get_class($subject) !== "Bolt\Storage\Entity\Content") {
+        if (!$subject instanceof Content) {
+            return;
+        }
+        if (isset($subject[$this->localeSlug . '_data'])) {
             return;
         }
 
-        $localeSlug = $this->localeSlug;
-
-        if (isset($subject[$localeSlug . '_data'])) {
-            $localeData = json_decode($subject[$localeSlug . '_data']);
-            foreach ($localeData as $key => $value) {
-                $subject->set($key, $value);
-            }
+        $localeData = json_decode($subject[$this->localeSlug . '_data']);
+        foreach ($localeData as $key => $value) {
+            $subject->set($key, $value);
         }
     }
 

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -276,13 +276,13 @@ class TranslateExtension extends SimpleExtension
     }
 
     /**
-     * Register overrides for bolt's services
+     * Register overrides for Bolt's services
      *
      * @param Application $app
      */
     private function registerOverrides(Application $app)
     {
-        $this->app['storage.legacy'] = $app->extend(
+        $app['storage.legacy'] = $app->extend(
             'storage.legacy',
             function ($storage) use ($app) {
                 return new Storage\Legacy($app);
@@ -297,7 +297,7 @@ class TranslateExtension extends SimpleExtension
                 return $frontend;
             }
         );
-        if ($this->app['translate.config']['menu_override']) {
+        if ($app['translate.config']['menu_override']) {
             $app['menu'] = $app->share(
                 function ($app) {
                     return new Frontend\LocalizedMenuBuilder($app);

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -397,4 +397,14 @@ class TranslateExtension extends SimpleExtension
 
         return new \Twig_Markup($html, 'UTF-8');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultConfig()
+    {
+        return [
+            'locales' => [],
+        ];
+    }
 }

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -407,8 +407,9 @@ class TranslateExtension extends SimpleExtension
     /**
      * Twig helper to render a locale switcher on the frontend
      *
-     * @param String $classes
-     * @param String $template
+     * @param array $args
+     *
+     * @return \Twig_Markup
      */
     public function localeSwitcher(array $args = [])
     {
@@ -418,7 +419,7 @@ class TranslateExtension extends SimpleExtension
         ];
         $args = array_merge($defaults, $args);
 
-        $html = $this->app['twig']->render($args['template'], [
+        $html = $this->renderTemplate($args['template'], [
             'classes' => $args['classes'],
         ]);
 


### PR DESCRIPTION
@SahAssar this is probably of most interest to you.

A few things:
 * `$config` is deliberately a private variable, as YAML loading depends on getConfig() being called
 * `$app` is the same, don't set/use a `$this->app` in the loader … that is not what it is there for
 * Avoid using `$app['request']` where ever possible, it will be populated regardless of where in the request cycle you are … the request stack however only gets set at the beginning of said cycle
 * Always develop extensions with `E_ALL`, developer notices, and Twig strict variables turned on, or you have :koala: PRs :laughing: 