### PR TITLE
Fix homepage redirect and _locale on 404's

### DIFF
--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -17,9 +17,6 @@ class LocalizedFrontend extends Frontend
                 if ($name !== 'preview') {
                     $route['path'] = '/{_locale}' . $route['path'];
                     $route['requirements']['_locale'] = '^[a-z]{2}(_[A-Z]{2})?$';
-
-                    // Using the url generator on a 404 response requires a default _locale to be set
-                    $route['defaults']['_locale'] = $this->app['translate.slug'];
                 }
             }
             $routes['homepageredir'] = ['path' => '/', 'defaults' => [ '_controller' => 'controller.frontend:homepageRedirect' ]];

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -101,7 +101,7 @@ class TranslateExtension extends SimpleExtension
                 $config = $app['translate.config'];
                 $request = $app['request_stack']->getCurrentRequest();
                 /** @var Config\Locale $locale */
-                $locale = current($config->getLocales());
+                $locale = reset($config->getLocales());
                 $defaultSlug = $locale->getSlug();
 
                 if ($request === null) {
@@ -146,6 +146,25 @@ class TranslateExtension extends SimpleExtension
                 return $frontend;
             }
         );
+
+        $app['url_generator'] = $app->extend(
+            'url_generator',
+            function ($urlGenerator) use ($app) {
+                $requestContext = $urlGenerator->getContext();
+
+                if (is_null($requestContext->getParameter('_locale'))) {
+                    $config = $app['translate.config'];
+                    /** @var Config\Locale $locale */
+                    $locale = reset($config->getLocales());
+                    $defaultSlug = $locale->getSlug();
+
+                    $requestContext->setParameter('_locale', $defaultSlug);
+                }
+
+                return $urlGenerator;
+            }
+        );
+
         if ($app['translate.config']->isMenuOverride()) {
             $app['menu'] = $app->share(
                 function ($app) {

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -114,7 +114,7 @@ class TranslateExtension extends SimpleExtension
                 }
 
                 foreach ($config->getLocales() as $locale) {
-                    if ($localeSlug = $locale->getSlug()) {
+                    if ($localeSlug == $locale->getSlug()) {
                         return $localeSlug;
                     }
                 }


### PR DESCRIPTION
* Removed default _locale in routing. Instead, extended url_generator to make sure _locale is always available as a parameter (for 404's). Fixes: #47
* Use `reset($config->getLocales());` instead of `current` to get the first entry.
* Fixed typo in code.
