### PR TITLE
Fix #47, #46 and #41 among other small issues

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -7,17 +7,23 @@ locales:
         label: Deutsch
         slug: de
 
-# Enable/disable automatic routing.
+# Enable/disable automatic routing override.
 # Enabling this will prefix all routes with {_locale} which leads to links like
 # /en/pages/yourpageslug It is reccomended that you leave this on unless you
 # want to build your own routing.
 routing_override: true
 
-# Enable/disable the menubuilder.
+# Enable/disable the menubuilder override.
 # Enabling this will make the menu output links in the format of the automatic
 # routing. It is reccomended that you leave this on unless you want to build
 # your own localized menus.
 menu_override: true
+
+# Enable/disable the url_generator override.
+# Enabling this will override the url generator to make sure that we don't
+# generate links without a locale. This is highlig reccomended to keep unless
+# you also build your own override since it can cause WSOD on 404's otherwise.
+url_generator_override: true
 
 # Enable/disable translated slugs.
 # Enabling this will use translated slugs instead of using the same slug for

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -110,4 +110,20 @@ class Config extends ParameterBag
     {
         $this->set('translate_slugs', $translateSlugs);
     }
+
+    /**
+     * @return boolean
+     */
+    public function isUrlGeneratorOverride()
+    {
+        return $this->get('url_generator_override', true);
+    }
+
+    /**
+     * @param boolean $urlGeneratorOverride
+     */
+    public function setUrlGeneratorOverride($urlGeneratorOverride)
+    {
+        $this->set('url_generator_override', $urlGeneratorOverride);
+    }
 }

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -204,9 +204,8 @@ class StorageListener implements EventSubscriberInterface
         }
 
         $localeSlug = $request->get('_locale');
-
         $subject = $event->getSubject();
-        
+
         if (!$subject instanceof Content) {
             return;
         }

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -21,9 +21,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class StorageListener implements EventSubscriberInterface
 {
-    /** @var string */
-    protected $localeSlug;
-
     /** @var BoltConfig */
     private $boltConfig;
     /** @var Query $query */
@@ -82,6 +79,8 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
+        $localeSlug = $request->get('_locale');
+
         /** @var Content $entity */
         $entity = $event->getArgument('entity');
         $subject = $event->getSubject();
@@ -93,8 +92,8 @@ class StorageListener implements EventSubscriberInterface
         $contentTypeName = $entity->getContenttype();
         $contentType = $this->boltConfig->get('contenttypes/' . $contentTypeName);
 
-        if (isset($subject[$this->localeSlug . '_data'])) {
-            $localeData = json_decode($subject[$this->localeSlug . '_data'], true);
+        if (isset($subject[$localeSlug . '_data'])) {
+            $localeData = json_decode($subject[$localeSlug . '_data'], true);
             foreach ($localeData as $key => $value) {
                 if ($contentType['fields'][$key]['type'] !== 'repeater') {
                     $subject[$key] = is_array($value) ? json_encode($value) : $value;
@@ -115,6 +114,8 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
+        $localeSlug = $request->get('_locale');
+
         /** @var Content $subject */
         $subject = $event->getSubject();
         if (!$subject instanceof Content || $request->query->getBoolean('no_locale_hydrate')) {
@@ -124,10 +125,10 @@ class StorageListener implements EventSubscriberInterface
         $contentTypeName = $subject->getContenttype();
         $contentType = $this->boltConfig->get('contenttypes/' . $contentTypeName);
 
-        if (!isset($subject[$this->localeSlug . '_data'])) {
+        if (!isset($subject[$localeSlug . '_data'])) {
             return;
         }
-        $localeData = json_decode($subject[$this->localeSlug . '_data'], true);
+        $localeData = json_decode($subject[$localeSlug . '_data'], true);
         foreach ($localeData as $key => $value) {
             if ($contentType['fields'][$key]['type'] !== 'repeater') {
                 continue;
@@ -158,9 +159,11 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
-        $record->set($this->localeSlug . '_slug', $values['slug']);
+        $localeSlug = $request->get('_locale');
+
+        $record->set($localeSlug . '_slug', $values['slug']);
         if ($values['locale'] == key($this->config->getLocales())) {
-            $record->set($this->localeSlug . '_data', '[]');
+            $record->set($localeSlug . '_data', '[]');
 
             return;
         }
@@ -181,7 +184,7 @@ class StorageListener implements EventSubscriberInterface
             }
         }
         $localeJson = json_encode($localeValues);
-        $record->set($this->localeSlug . '_data', $localeJson);
+        $record->set($localeSlug . '_data', $localeJson);
     }
 
     /**
@@ -195,11 +198,13 @@ class StorageListener implements EventSubscriberInterface
         if (!$subject instanceof Content) {
             return;
         }
-        if (isset($subject[$this->localeSlug . '_data'])) {
+        if (isset($subject[$localeSlug . '_data'])) {
             return;
         }
 
-        $localeData = json_decode($subject[$this->localeSlug . '_data']);
+        $localeSlug = $request->get('_locale');
+
+        $localeData = json_decode($subject[$localeSlug . '_data']);
         foreach ($localeData as $key => $value) {
             $subject->set($key, $value);
         }

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -209,7 +209,7 @@ class StorageListener implements EventSubscriberInterface
         if (!$subject instanceof Content) {
             return;
         }
-        if (isset($subject[$localeSlug . '_data'])) {
+        if (!isset($subject[$localeSlug . '_data'])) {
             return;
         }
 

--- a/src/Frontend/LocalizedFrontend.php
+++ b/src/Frontend/LocalizedFrontend.php
@@ -13,13 +13,25 @@ class LocalizedFrontend extends Frontend
         $routes = $this->app['config']->get('routing', []);
 
         if ($this->app['translate.config']->isRoutingOverride()) {
+            /** @var Config\Config $config */
+            $config = $this->app['translate.config'];
+            foreach ($config->getLocales() as $locale) {
+                $requirements = $locale->getSlug() . '|' . $requirements;
+            }
+
             foreach ($routes as $name => &$route) {
                 if ($name !== 'preview') {
                     $route['path'] = '/{_locale}' . $route['path'];
-                    $route['requirements']['_locale'] = '^[a-z]{2}(_[A-Z]{2})?$';
+                    $route['requirements']['_locale'] = $requirements;
                 }
             }
-            $routes['homepageredir'] = ['path' => '/', 'defaults' => [ '_controller' => 'controller.frontend:homepageRedirect' ]];
+
+            $routes = array_merge([
+                    'homepageredir' => [
+                        'path' => '/',
+                        'defaults' => ['_controller' => 'controller.frontend:homepageRedirect']
+                    ]
+                ], $routes);
         }
 
         return $routes;

--- a/src/Frontend/LocalizedMenuBuilder.php
+++ b/src/Frontend/LocalizedMenuBuilder.php
@@ -75,7 +75,7 @@ class LocalizedMenuBuilder extends MenuBuilder
     private function resolvePathToContent(array $item)
     {
         if ($item['path'] === 'homepage') {
-            $item['link'] = $this->app['resources']->getUrl('root') . $this->prefix;
+            $item['link'] = rtrim($this->app['resources']->getUrl('root') . $this->prefix, '/');
 
             return $item;
         }
@@ -124,6 +124,8 @@ class LocalizedMenuBuilder extends MenuBuilder
         } catch (MethodNotAllowedException $e) {
             // Route is probably a GET and we're currently in a POST
         }
+
+
 
         return $item;
     }

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -154,27 +154,26 @@ class TranslateExtension extends SimpleExtension
             }
         );
 
-<<<<<<< ad5143b99bd4b77fa332bd6150e0392ca6c466c1
-        $app['url_generator'] = $app->extend(
-            'url_generator',
-            function ($urlGenerator) use ($app) {
-                $requestContext = $urlGenerator->getContext();
+        if ($app['translate.config']->isUrlGeneratorOverride()) {
+            $app['url_generator'] = $app->extend(
+                'url_generator',
+                function ($urlGenerator) use ($app) {
+                    $requestContext = $urlGenerator->getContext();
 
-                if (is_null($requestContext->getParameter('_locale'))) {
-                    $config = $app['translate.config'];
-                    /** @var Config\Locale $locale */
-                    $locale = reset($config->getLocales());
-                    $defaultSlug = $locale->getSlug();
+                    if (is_null($requestContext->getParameter('_locale'))) {
+                        $config = $app['translate.config'];
+                        /** @var Config\Locale $locale */
+                        $locale = reset($config->getLocales());
+                        $defaultSlug = $locale->getSlug();
 
-                    $requestContext->setParameter('_locale', $defaultSlug);
+                        $requestContext->setParameter('_locale', $defaultSlug);
+                    }
+
+                    return $urlGenerator;
                 }
+            );
+        }
 
-                return $urlGenerator;
-            }
-        );
-
-=======
->>>>>>> fix typos, PSR2 warning, locale param in querystring
         if ($app['translate.config']->isMenuOverride()) {
             $app['menu'] = $app->share(
                 function ($app) {

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -44,7 +44,14 @@ class TranslateExtension extends SimpleExtension
     protected function subscribe(EventDispatcherInterface $dispatcher)
     {
         $app = $this->getContainer();
-        $dispatcher->addSubscriber(new EventListener\StorageListener($app['config'], $app['translate.config'], $app['query'], $app['request_stack']));
+        $dispatcher->addSubscriber(
+            new EventListener\StorageListener(
+                $app['config'],
+                $app['translate.config'],
+                $app['query'],
+                $app['request_stack']
+            )
+        );
     }
 
     /**
@@ -114,7 +121,7 @@ class TranslateExtension extends SimpleExtension
                 }
 
                 foreach ($config->getLocales() as $locale) {
-                    if ($localeSlug == $locale->getSlug()) {
+                    if ($localeSlug === $locale->getSlug()) {
                         return $localeSlug;
                     }
                 }
@@ -147,6 +154,7 @@ class TranslateExtension extends SimpleExtension
             }
         );
 
+<<<<<<< ad5143b99bd4b77fa332bd6150e0392ca6c466c1
         $app['url_generator'] = $app->extend(
             'url_generator',
             function ($urlGenerator) use ($app) {
@@ -165,6 +173,8 @@ class TranslateExtension extends SimpleExtension
             }
         );
 
+=======
+>>>>>>> fix typos, PSR2 warning, locale param in querystring
         if ($app['translate.config']->isMenuOverride()) {
             $app['menu'] = $app->share(
                 function ($app) {
@@ -227,17 +237,17 @@ class TranslateExtension extends SimpleExtension
         /** @var Config\Locale $locale */
         foreach ($locales as $iso => $locale) {
             $requestAttributes = $request->attributes->get('_route_params');
-            $requestLocale = isset($requestAttributes['_locale']) ? $requestAttributes['_locale'] : null;
+            $requestLocale = $request->get('_locale');
             if ($config->isTranslateSlugs() && $locale->getSlug() !== $requestLocale && $request->get('slug')) {
                 $repo = $app['storage']->getRepository('pages');
                 $qb = $repo->createQueryBuilder();
                 $qb->select($locale->getSlug() . '_slug')
-                    ->where($requestAttributes['_locale'] . '_slug = ?')
+                    ->where($locale->getSlug() . '_slug = ?')
                     ->setParameter(0, $request->get('slug'))
                 ;
                 $newSlug = $repo->findOneWith($qb);
                 if ($newSlug) {
-                    $requestAttributes['slug'] = $newSlug;
+                    $requestAttributes['slug'] = $newSlug[$locale->getSlug() . '_slug'];
                 }
             }
 

--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -1,20 +1,21 @@
-{% set locales = app['translate.config'].locales %}
-{% set current = locales|first %}
+{% set locales = app['translate.config'].getLocales() %}
 {% set currentkey = locales|keys|first %}
+{% set current = locales|first %}
 {% set translatable = [] %}
 
 {% for name, field in context.contenttype.fields %}
     {% if field.is_translateable is defined and field.is_translateable == true %}
         {% set translatable = translatable|merge(['#'~name]) %}
+        {% set translatable = translatable|merge(['[name^="'~name~'[0]"]']) %}
     {% endif %}
 {% endfor %}
 
 {% for key, option in locales %}
-    {% set current = option.get('slug') == app.request.get('_locale') ? option.get('slug') : current %}
-    {% set currentkey = option.get('slug') == app.request.get('_locale') ? key : currentkey %}
+    {% set current    = option.get('slug') == app['translate.slug'] ? option : current %}
+    {% set currentkey = option.get('slug') == app['translate.slug'] ? key : currentkey %}
 {% endfor %}
 <input name="locale" type="hidden" value="{{currentkey}}">
-<input name="_locale" type="hidden" value="{{current.slug}}">
+<input name="_locale" type="hidden" value="{{current.get('slug')}}">
 <input name="no_locale_hydrate" type="hidden" value="true">
 
 <fieldset class="locale">
@@ -22,7 +23,7 @@
         {% if app.request.get('id') is not empty %}
         <div class="dropdown pull-right" id="locale-select">
             <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button">
-                <span class="selected">{{ current.label }}</span>
+                <span class="selected">{{ current.get('label') }}</span>
                 <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">
@@ -43,8 +44,8 @@
 <script>
     $(function() {
         // Prepend translation icons to translatable fields.
-        $('{{translatable|join(",")}}')
-            .closest('fieldset')
+        $('{{translatable|join(",")|raw}}')
+            .closest('[data-bolt-fieldset]')
             .each(function(i, el){
                 $(el).find('label')
                     .first()
@@ -60,7 +61,7 @@
         $('#sidebarpreviewbutton')
             .attr(
                 'data-url',
-                "{{ path('preview', {'contenttypeslug': context.contenttype.singular_slug, _locale: current.slug}) }}"
+                "{{ path('preview', {'contenttypeslug': context.contenttype.singular_slug, _locale: current.get('slug')}) }}"
             );
 
         {% if context.content.slug|default(false) %}
@@ -68,11 +69,12 @@
             $('[href="{{ context.content.link }}"]')
                 .attr(
                     'href',
-                    "{{ path('contentlink', {'contenttypeslug': context.contenttype.singular_slug, slug: context.content.slug, _locale: current.slug}) }}"
+                    "{{ path('contentlink', {'contenttypeslug': context.contenttype.singular_slug, slug: context.content.slug, _locale: current.get('slug')}) }}"
                 );
         {% endif %}
     });
 </script>
+
 <style>
     #locale-select button {
         border-radius: 4px 4px 0 0;

--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -14,7 +14,6 @@
     {% set current    = option.get('slug') == app['translate.slug'] ? option : current %}
     {% set currentkey = option.get('slug') == app['translate.slug'] ? key : currentkey %}
 {% endfor %}
-<input name="locale" type="hidden" value="{{currentkey}}">
 <input name="_locale" type="hidden" value="{{current.get('slug')}}">
 <input name="no_locale_hydrate" type="hidden" value="true">
 

--- a/templates/frontend/_localeswitcher.twig
+++ b/templates/frontend/_localeswitcher.twig
@@ -1,8 +1,8 @@
 <ul{% if classes %} class="{{ classes }}"{% endif %}>
-    {% for iso, locale in locales %}
-    <li{% if locale.active %} class="active"{% endif %}>
-        <a title="{{ locale.label }}" href="{{ locale.url }}">
-            {{ locale.label }}
+    {% for locale in locales %}
+    <li{% if locale.get('active') %} class="active"{% endif %}>
+        <a title="{{ locale.get('label') }}" href="{{ locale.get('url') }}">
+            {{ locale.get('label') }}
         </a>
     {% endfor %}
 </ul>


### PR DESCRIPTION
* Fix request cycle issues with the default locale in the routing override
* Move the homepageredirect to the top of the routes, fixes #47
* Add requirements to all routes based on the locales configured to avoid DC issues
* fix a few typos/minor errors
* Change how we look for the locale param so that it is allowed in a query string (required for preview and editcontent), fixes #46
* Add in a js to add the icon to repeaters, fixes #41
* Actually get the localeSlug in the StorageListener, (ping @gawainlynch for better way to do it since it comes from the request)
* Fix PSR2 warning for line length
* Ensure consistent usage between `current.get('slug')` and `current.slug`