### PR TITLE
Redirect to locale based on Accept-Language header

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -9,19 +9,19 @@ locales:
 
 # Enable/disable automatic routing override.
 # Enabling this will prefix all routes with {_locale} which leads to links like
-# /en/pages/yourpageslug It is reccomended that you leave this on unless you
+# /en/pages/yourpageslug It is recommended that you leave this on unless you
 # want to build your own routing.
 routing_override: true
 
 # Enable/disable the menubuilder override.
 # Enabling this will make the menu output links in the format of the automatic
-# routing. It is reccomended that you leave this on unless you want to build
+# routing. It is recommended that you leave this on unless you want to build
 # your own localized menus.
 menu_override: true
 
 # Enable/disable the url_generator override.
 # Enabling this will override the url generator to make sure that we don't
-# generate links without a locale. This is highlig reccomended to keep unless
+# generate links without a locale. This is highlig recommended to keep unless
 # you also build your own override since it can cause WSOD on 404's otherwise.
 url_generator_override: true
 
@@ -29,3 +29,10 @@ url_generator_override: true
 # Enabling this will use translated slugs instead of using the same slug for
 # all languages. Only set to false if you also don't set your slugs to `is_translateable`. 
 translate_slugs: true
+
+# Enable/disable using Accept-Language header to determine the locale for
+# redirection on `/`.
+# Enabling this will redirect visitors on `/` to the preferred locale based on
+# the Accept-Language header. Disabling this will always redirect `/` to the
+# first locale set in `locales` above.
+use_accept_language_header: true

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -126,4 +126,20 @@ class Config extends ParameterBag
     {
         $this->set('url_generator_override', $urlGeneratorOverride);
     }
+
+    /**
+     * @return boolean
+     */
+    public function isUseAcceptLanguageHeader()
+    {
+        return $this->getBoolean('use_accept_language_header', true);
+    }
+
+    /**
+     * @param boolean $useAcceptLanguageHeader
+     */
+    public function setUseAcceptLanguageHeader($useAcceptLanguageHeader)
+    {
+        $this->set('use_accept_language_header', $useAcceptLanguageHeader);
+    }
 }

--- a/src/Routing/LocalizedUrlGenerator.php
+++ b/src/Routing/LocalizedUrlGenerator.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Bolt\Extension\Animal\Translate\Routing;
+
+use Silex\Application;
+use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Wraps a UrlGenerator to make sure the _locale parameter is always set.
+ *
+ * @author Peter Verraedt <peter@verraedt.be>
+ */
+class LocalizedUrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
+{
+    /** @var UrlGeneratorInterface */
+    protected $wrapped;
+
+    /**
+     * UrlGeneratorFragmentWrapper constructor.
+     *
+     * @param UrlGeneratorInterface $wrapped
+     */
+    public function __construct(UrlGeneratorInterface $wrapped, Application $app)
+    {
+        $this->wrapped = $wrapped;
+        $this->app = $app;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Makes sure the _locale parameter is always set.
+     */
+    public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    {
+        if (!isset($parameters['_locale'])) {
+            $parameters['_locale'] = $this->app['translate.slug'];
+        }
+
+        return $this->wrapped->generate($name, $parameters, $referenceType);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContext(RequestContext $context)
+    {
+        $this->wrapped->setContext($context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContext()
+    {
+        return $this->wrapped->getContext();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStrictRequirements($enabled)
+    {
+        if ($this->wrapped instanceof ConfigurableRequirementsInterface) {
+            $this->wrapped->setStrictRequirements($enabled);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStrictRequirements()
+    {
+        if ($this->wrapped instanceof ConfigurableRequirementsInterface) {
+            return $this->wrapped->isStrictRequirements();
+        }
+
+        return null; // requirements check is deactivated completely
+    }
+}

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -175,13 +175,26 @@ class TranslateExtension extends SimpleExtension
                     $requestContext = $urlGenerator->getContext();
 
                     if (is_null($requestContext->getParameter('_locale'))) {
-                        $config = $app['translate.config'];
-                        /** @var Config\Locale $locale */
-                        $locale = $config->getLocales();
-                        $locale = reset($locale);
-                        $defaultSlug = $locale->getSlug();
+                        $request = $app['request_stack']->getCurrentRequest();
 
-                        $requestContext->setParameter('_locale', $defaultSlug);
+                        /* Only set _locale if request is not null */
+                        if ($request !== null) {
+                            $localeNames = array();
+                            /** @var Config\Config $config */
+                            $config = $app['translate.config'];
+
+                            foreach ($config->getLocales() as $name => $locale) {
+                                /** @var Config\Locale $locale */
+                                $localeNames[$name] = $locale->getSlug();
+                                if (preg_match('/([a-z]{2})_[A-Z]{2}/', $name, $match)) {
+                                    $localeNames[$match[1]] = $locale->getSlug();
+                                }
+                            }
+
+                            $defaultName = $request->getPreferredLanguage(array_keys($localeNames));
+                            $defaultSlug = $localeNames[$defaultName];
+                            $requestContext->setParameter('_locale', $defaultSlug);
+                        }
                     }
 
                     return $urlGenerator;


### PR DESCRIPTION
Use the `Accept-Language` header to determine the best locale, if the `_locale` parameter is not set in the url. More precisely:

* Redirect `/` to the preferred locale, using the `Accept-Language` header, instead of redirecting to the first locale set in the configuration.
* Render 404 responses in the preferred locale using the `Accept-Language` header, instead of the first locale set in the configuration.
* All urls starting with `/{_locale}` have unchanged behaviour, they ignore the `Accept-Language` header.

Two remarks:
* Negotiating is based on Symfony's `Symfony\Component\HttpFoundation\Request::getPreferredLanguage`. This function needs an array of the supported locales on the website. In my current implementation, I supply both `en_GB` and `en` if `en_GB` is set in the configuration, so that `en_US` users will also get the English version.
* The `url_generator` override is cleaned up and now automatically sets the `_locale` parameter to the current `$app['translate.slug']`.