### PR TITLE
Fixed #61

### DIFF
--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -246,7 +246,7 @@ class TranslateExtension extends SimpleExtension
                 $repo = $app['storage']->getRepository('pages');
                 $qb = $repo->createQueryBuilder();
                 $qb->select($locale->getSlug() . '_slug')
-                    ->where($locale->getSlug() . '_slug = ?')
+                    ->where($app['translate.slug'] . '_slug = ?')
                     ->setParameter(0, $request->get('slug'))
                 ;
                 $newSlug = $repo->findOneWith($qb);


### PR DESCRIPTION
Resolves an issue, where the locale.url parameter would always show the taxonomy slug in the default locale.

Fixes: #61

@SahAssar Could you have a quick look and merge it, if you're OK with the fix?