### PR TITLE
Implement ArrayAccess in Locale to allow |order() in twig

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If you want to output the localeswitcher (or some part of it) anywhere you have
 access to an array called `locales` in basically any template that you use.
 Using this you can craft basically any locale selector you want, see #30 for
 more info. To see the structure please dump it by using `{{ dump(locales) }}`.
+The array `locales` can be ordered based on the active locale by using the 
+`|order()` filter, like this: `{% for locale in locales|order('-active') %}`.
 
 ### Overrides
 

--- a/src/Config/Locale.php
+++ b/src/Config/Locale.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Extension\Animal\Translate\Config;
 
+use ArrayAccess;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
 /**
@@ -9,8 +10,45 @@ use Symfony\Component\HttpFoundation\ParameterBag;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class Locale extends ParameterBag
+class Locale extends ParameterBag implements ArrayAccess
 {
+    /**
+     * @see ArrayAccess::offsetSet
+     *
+     * @param $offset
+     * @param $value
+     */
+    public function offsetSet($offset, $value) {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * @see ArrayAccess::offsetUnset
+     *
+     * @param int $offset
+     */
+    public function offsetUnset($offset) {
+        $this->remove($offset);
+    }
+
+    /**
+     * @see ArrayAccess::offsetExists
+     *
+     * @param $offset
+     */
+    public function offsetExists($offset) {
+        return $this->has($offset);
+    }
+
+    /**
+     * @see ArrayAccess::offsetGet
+     *
+     * @param $offset
+     */
+    public function offsetGet($offset) {
+        return $this->get($offset);
+    }
+
     /**
      * @return string
      */


### PR DESCRIPTION
Implement ArrayAccess in Locale to allow the locales array to be ordered with `|order()`.

For example, if one always wants to have the active locale first:
```
<ul{% if classes %} class="{{ classes }}"{% endif %}>
    {% for locale in locales|order('-active') %}
    <li{% if locale.get('active') %} class="active"{% endif %}>
        <a title="{{ locale.get('label') }}" href="{{ locale.get('url') }}">
            {{ locale.get('label') }}
        </a>
    {% endfor %}
</ul>
```
This fixes the other question mentioned in #61: "how do i get the active locale first without looping twice?" and was also mentioned way back in #5

@madc Please have a look and merge if you feel this looks okay