### PR TITLE
Hydrate repeaters in templatefields

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -21,7 +21,7 @@ class Config extends ParameterBag
         parent::__construct($config);
         foreach ($config['locales'] as $name => $parameters) {
             $this->parameters['locales'][$name] = new Locale($parameters);
-         }
+        }
     }
 
     /**

--- a/src/Config/Locale.php
+++ b/src/Config/Locale.php
@@ -18,7 +18,8 @@ class Locale extends ParameterBag implements ArrayAccess
      * @param $offset
      * @param $value
      */
-    public function offsetSet($offset, $value) {
+    public function offsetSet($offset, $value)
+    {
         $this->set($offset, $value);
     }
 
@@ -27,7 +28,8 @@ class Locale extends ParameterBag implements ArrayAccess
      *
      * @param int $offset
      */
-    public function offsetUnset($offset) {
+    public function offsetUnset($offset)
+    {
         $this->remove($offset);
     }
 
@@ -36,7 +38,8 @@ class Locale extends ParameterBag implements ArrayAccess
      *
      * @param $offset
      */
-    public function offsetExists($offset) {
+    public function offsetExists($offset)
+    {
         return $this->has($offset);
     }
 
@@ -45,7 +48,8 @@ class Locale extends ParameterBag implements ArrayAccess
      *
      * @param $offset
      */
-    public function offsetGet($offset) {
+    public function offsetGet($offset)
+    {
         return $this->get($offset);
     }
 

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -130,6 +130,21 @@ class StorageListener implements EventSubscriberInterface
         }
         $localeData = json_decode($subject[$localeSlug . '_data'], true);
         foreach ($localeData as $key => $value) {
+            
+            if ($key === 'templatefields') {
+                $templateFields = $this->boltConfig->get('theme/templatefields/' . $subject['template'] . '/fields');
+                foreach ($templateFields as $key => $field) {
+                    if($field['type'] === 'repeater'){
+                        $repeaterData = json_decode($value[$key], true);
+                        /** @var RepeatingFieldCollection[] $subject */
+                        $subject['templatefields'][$key]->clear();
+                        foreach ($repeaterData as $subValue) {
+                            $subject['templatefields'][$key]->addFromArray($subValue);
+                        }
+                    }
+                }
+            }
+        
             if ($contentType['fields'][$key]['type'] !== 'repeater') {
                 continue;
             }
@@ -180,6 +195,16 @@ class StorageListener implements EventSubscriberInterface
                 ['id' => $values['id'], 'returnsingle' => true]
             );
         }
+
+        if (in_array('templatefields', $translatableFields)) {
+            $templateFields = $this->boltConfig->get('theme/templatefields/' . $values['template'] . '/fields');
+            foreach ($templateFields as $key => $field) {
+                if($field['type'] === 'repeater'){
+                    $values['templatefields'][$key] = json_encode($values['templatefields'][$key]);
+                }
+            }
+        }
+
         foreach ($translatableFields as $field) {
             $localeValues[$field] = $values[$field];
             if ($values['id']) {

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -130,11 +130,10 @@ class StorageListener implements EventSubscriberInterface
         }
         $localeData = json_decode($subject[$localeSlug . '_data'], true);
         foreach ($localeData as $key => $value) {
-            
             if ($key === 'templatefields') {
                 $templateFields = $this->boltConfig->get('theme/templatefields/' . $subject['template'] . '/fields');
                 foreach ($templateFields as $key => $field) {
-                    if($field['type'] === 'repeater'){
+                    if ($field['type'] === 'repeater') {
                         $repeaterData = json_decode($value[$key], true);
                         /** @var RepeatingFieldCollection[] $subject */
                         $subject['templatefields'][$key]->clear();
@@ -199,7 +198,7 @@ class StorageListener implements EventSubscriberInterface
         if (in_array('templatefields', $translatableFields)) {
             $templateFields = $this->boltConfig->get('theme/templatefields/' . $values['template'] . '/fields');
             foreach ($templateFields as $key => $field) {
-                if($field['type'] === 'repeater'){
+                if ($field['type'] === 'repeater') {
                     $values['templatefields'][$key] = json_encode($values['templatefields'][$key]);
                 }
             }

--- a/src/Storage/ContentTypeTable.php
+++ b/src/Storage/ContentTypeTable.php
@@ -33,7 +33,7 @@ class ContentTypeTable extends ContentType
         /** @var Config\Locale $locale */
         foreach ($this->config->getLocales() as $locale) {
             $this->table->addColumn($locale->getSlug() . '_slug', 'string', ['length'  => 191, 'default' => '']);
-            $this->table->addColumn($locale->getSlug() . '_data', 'text',   ['notnull' => false]);
+            $this->table->addColumn($locale->getSlug() . '_data', 'text', ['notnull' => false]);
         }
     }
 

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -103,7 +103,7 @@ class Legacy extends Storage
                     }
                 }
                 if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
-                    /* 
+                    /**
                      * Hackish fix until #5533 gets fixed, after that the
                      * following four (4) lines can be replaced with 
                      * "$record[$key]->clear();"

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -105,7 +105,7 @@ class Legacy extends Storage
                 if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
                     /**
                      * Hackish fix until #5533 gets fixed, after that the
-                     * following four (4) lines can be replaced with 
+                     * following four (4) lines can be replaced with
                      * "$record[$key]->clear();"
                     */
                     $originalMapping[$key]['fields'] = $contentType['fields'][$key]['fields'];

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -80,9 +80,29 @@ class Legacy extends Storage
 
         if (isset($values[$localeSlug . '_data'])) {
             $localeData = json_decode($values[$localeSlug . '_data'], true);
-            
             foreach ($localeData as $key => $value) {
-                if ($contentType['fields'][$key]['type'] === 'repeater') {
+                if ($key === 'templatefields') {
+                    $templateFields = $app['config']->get('theme/templatefields/' . $record['template'] . '/fields');
+                    foreach ($templateFields as $key => $field) {
+                        if ($field['type'] === 'repeater') {
+                            $localeData = json_decode($value[$key], true);
+                            $originalMapping = null;
+                            $originalMapping[$key]['fields'] = $templateFields[$key]['fields'];
+                            $originalMapping[$key]['type'] = 'repeater';
+
+                            $mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
+                            $repeater = new RepeatingFieldCollection($app['storage'], $mapping);
+                            $repeater->setName($key);
+
+                            foreach ($localeData as $subValue) {
+                                $repeater->addFromArray($subValue);
+                            }
+
+                            $record['templatefields'][$key] = $repeater;
+                        }
+                    }
+                }
+                if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
                     /* 
                      * Hackish fix until #5533 gets fixed, after that the
                      * following four (4) lines can be replaced with 
@@ -92,6 +112,7 @@ class Legacy extends Storage
                     $originalMapping[$key]['type'] = 'repeater';
                     $mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
                     $record[$key] = new RepeatingFieldCollection($app['storage'], $mapping);
+                    
                     foreach ($value as $subValue) {
                         $record[$key]->addFromArray($subValue);
                     }


### PR DESCRIPTION
This fixes #57.

Keep in mind that since hydration for templatefields in repeaters didn't land until bolt/bolt#5670 in core this won't work on current stable, only on release/3.0 or master (or release/3.1).

@madc You know the drill :wink: 