### PR TITLE
Set $app['locale'] to locale name instead of locale slug

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -36,3 +36,6 @@ translate_slugs: true
 # the Accept-Language header. Disabling this will always redirect `/` to the
 # first locale set in `locales` above.
 use_accept_language_header: false
+
+# Enable/disable translation of the dashboard.
+translate_dashboard: false

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -132,7 +132,7 @@ class Config extends ParameterBag
      */
     public function isUseAcceptLanguageHeader()
     {
-        return $this->getBoolean('use_accept_language_header', true);
+        return $this->getBoolean('use_accept_language_header', false);
     }
 
     /**
@@ -141,5 +141,21 @@ class Config extends ParameterBag
     public function setUseAcceptLanguageHeader($useAcceptLanguageHeader)
     {
         $this->set('use_accept_language_header', $useAcceptLanguageHeader);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isTranslateDashboard()
+    {
+        return $this->getBoolean('translate_dashboard', false);
+    }
+
+    /**
+     * @param boolean $translateDashboard
+     */
+    public function setTranslateDashboard($translateDashboard)
+    {
+        $this->set('translate_dashboard', $translateDashboard);
     }
 }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -29,14 +29,20 @@ class LocaleListener extends BaseLocaleListener
    {
        parent::onKernelRequest($event);
 
-       $localeSlug = $event->getRequest()->getLocale();
+       $request = $event->getRequest();
 
-       /** @var Config\Locale $locale */
-       $locales = $this->config->getLocales();
+       if ($localeSlug = $request->get('_locale')) {
+           /** @var Config\Locale $locale */
+           $locales = $this->config->getLocales();
 
-       foreach ($locales as $name => $locale) {
-           if ($locale->getSlug() === $localeSlug) {
-               $this->app['locale'] = $name;
+           foreach ($locales as $name => $locale) {
+               if ($locale->getSlug() === $localeSlug) {
+                   // Override $request locale
+                   $request->setLocale($name);
+
+                   // Reset $app['locale']
+                   $this->app['locale'] = $name;
+               }
            }
        }
    }

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -31,7 +31,16 @@ class LocaleListener extends BaseLocaleListener
 
        $request = $event->getRequest();
 
-       if ($localeSlug = $request->get('_locale')) {
+       if ($this->config->isTranslateDashboard()) {
+           // If the dashboard is translated, we need to get _locale from routing attributes (frontend) and from the query (backend).
+           $localeSlug = $request->get('_locale');
+       }
+       else {
+           // If the dashboard is not translated, we only need to check routing attributes.
+           $localeSlug = $request->attributes->get('_locale');
+       }
+
+       if ($localeSlug) {
            /** @var Config\Locale $locale */
            $locales = $this->config->getLocales();
 

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bolt\Extension\Animal\Translate\EventListener;
+
+use Bolt\Extension\Animal\Translate\Config\Config;
+use Silex\Application;
+use Silex\EventListener\LocaleListener as BaseLocaleListener;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContextAwareInterface;
+
+/**
+ *  Initializes the locale based on the current request.
+ *
+ * @author Peter Verraedt <peter@verraedt.be>
+ */
+class LocaleListener extends BaseLocaleListener
+{
+   private $config;
+
+   public function __construct(Config $config, Application $app, RequestContextAwareInterface $router = null, RequestStack $requestStack = null)
+   {
+       $this->config = $config;
+       parent::__construct($app, $router, $requestStack);
+   }
+
+   public function onKernelRequest(GetResponseEvent $event)
+   {
+       parent::onKernelRequest($event);
+
+       $localeSlug = $event->getRequest()->getLocale();
+
+       /** @var Config\Locale $locale */
+       $locales = $this->config->getLocales();
+
+       foreach ($locales as $name => $locale) {
+           if ($locale->getSlug() === $localeSlug) {
+               $this->app['locale'] = $name;
+           }
+       }
+   }
+}

--- a/src/TranslateExtension.php
+++ b/src/TranslateExtension.php
@@ -212,7 +212,7 @@ class TranslateExtension extends SimpleExtension
                 function (array $resources, $app) {
                     foreach ($app['translate.config']->getLocales() as $name => $locale) {
                         // $app['locale'] contains default locale at this point
-                        if ($locale != $app['locale'] && !in_array($locale,  $app['locale_fallbacks'])) {
+                        if ($locale !== $app['locale'] && !in_array($locale,  $app['locale_fallbacks'])) {
                             $resources = array_merge(\Bolt\Provider\TranslationServiceProvider::addResources($app, $name), $resources);
                         }
                     }


### PR DESCRIPTION
At this moment, Silex sets the request locale and the variable `$app['locale']` to the value `$request->get('_locale')`. However, the latter only contains the locale slug (e.g. "en") and not the locale name (e.g. "en_US"). The added file `LocaleListener.php` fixes this. 

Together with the addition of the code in `TranslateExtension.php` which loads the translator resources for all locales, this enables the built in translator to translate standard messages in the appropriate language. 

Note that for testing purposes on an existing installation of bolt, it might be necessary to clean the directory `app/cache/trans` manually.