### PR TITLE
Fixing issue with empty _data field

### DIFF
--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -92,13 +92,16 @@ class StorageListener implements EventSubscriberInterface
         $contentTypeName = $entity->getContenttype();
         $contentType = $this->boltConfig->get('contenttypes/' . $contentTypeName);
 
-        if (isset($subject[$localeSlug . 'data']) && is_array($subject[$localeSlug . 'data'])) {
+        if (isset($subject[$localeSlug . 'data'])) {
             $localeData = json_decode($subject[$localeSlug . 'data'], true);
-            foreach ($localeData as $key => $value) {
-                if ($contentType['fields'][$key]['type'] !== 'repeater') {
-                    $subject[$key] = is_array($value) ? json_encode($value) : $value;
-                }
-            }
+			
+			if ($localeData !== null) {
+				foreach ($localeData as $key => $value) {
+					if ($contentType['fields'][$key]['type'] !== 'repeater') {
+						$subject[$key] = is_array($value) ? json_encode($value) : $value;
+					}
+				}
+			}
         }
     }
 

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -92,7 +92,7 @@ class StorageListener implements EventSubscriberInterface
         $contentTypeName = $entity->getContenttype();
         $contentType = $this->boltConfig->get('contenttypes/' . $contentTypeName);
 
-        if (isset($subject[$localeSlug . 'data'])) {
+        if (isset($subject[$localeSlug . 'data']) && is_array($subject[$localeSlug . 'data'])) {
             $localeData = json_decode($subject[$localeSlug . 'data'], true);
             foreach ($localeData as $key => $value) {
                 if ($contentType['fields'][$key]['type'] !== 'repeater') {

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -80,46 +80,49 @@ class Legacy extends Storage
         $values = $this->localeValues;
         $localeSlug = $app['translate.slug'];
 
-        if (isset($values[$localeSlug . 'data']) && is_array($values[$localeSlug . 'data'])) {
+        if (isset($values[$localeSlug . 'data'])) {
             $localeData = json_decode($values[$localeSlug . 'data'], true);
-            foreach ($localeData as $key => $value) {
-                if ($key === 'templatefields') {
-                    $templateFields = $app['config']->get('theme/templatefields/' . $record['template'] . '/fields');
-                    foreach ($templateFields as $key => $field) {
-                        if ($field['type'] === 'repeater') {
-                            $localeData = json_decode($value[$key], true);
-                            $originalMapping = null;
-                            $originalMapping[$key]['fields'] = $templateFields[$key]['fields'];
-                            $originalMapping[$key]['type'] = 'repeater';
-
-                            $mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
-                            $repeater = new RepeatingFieldCollection($app['storage'], $mapping);
-                            $repeater->setName($key);
-
-                            foreach ($localeData as $subValue) {
-                                $repeater->addFromArray($subValue);
-                            }
-
-                            $record['templatefields'][$key] = $repeater;
-                        }
-                    }
-                }
-                if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
-                    /**
-                     * Hackish fix until #5533 gets fixed, after that the
-                     * following four (4) lines can be replaced with
-                     * "$record[$key]->clear();"
-                    */
-                    $originalMapping[$key]['fields'] = $contentType['fields'][$key]['fields'];
-                    $originalMapping[$key]['type'] = 'repeater';
-                    $mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
-                    $record[$key] = new RepeatingFieldCollection($app['storage'], $mapping);
-                    
-                    foreach ($value as $subValue) {
-                        $record[$key]->addFromArray($subValue);
-                    }
-                }
-            }
+			
+			if ($localeData !== null) {
+				foreach ($localeData as $key => $value) {
+					if ($key === 'templatefields') {
+						$templateFields = $app['config']->get('theme/templatefields/' . $record['template'] . '/fields');
+						foreach ($templateFields as $key => $field) {
+							if ($field['type'] === 'repeater') {
+								$localeData = json_decode($value[$key], true);
+								$originalMapping = null;
+								$originalMapping[$key]['fields'] = $templateFields[$key]['fields'];
+								$originalMapping[$key]['type'] = 'repeater';
+								
+								$mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
+								$repeater = new RepeatingFieldCollection($app['storage'], $mapping);
+								$repeater->setName($key);
+								
+								foreach ($localeData as $subValue) {
+									$repeater->addFromArray($subValue);
+								}
+								
+								$record['templatefields'][$key] = $repeater;
+							}
+						}
+					}
+					if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
+						/**
+						* Hackish fix until #5533 gets fixed, after that the
+						* following four (4) lines can be replaced with
+						* "$record[$key]->clear();"
+						*/
+						$originalMapping[$key]['fields'] = $contentType['fields'][$key]['fields'];
+						$originalMapping[$key]['type'] = 'repeater';
+						$mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);
+						$record[$key] = new RepeatingFieldCollection($app['storage'], $mapping);
+						
+						foreach ($value as $subValue) {
+							$record[$key]->addFromArray($subValue);
+						}
+					}
+				}
+			}
         }
     }
 }

--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -80,7 +80,7 @@ class Legacy extends Storage
         $values = $this->localeValues;
         $localeSlug = $app['translate.slug'];
 
-        if (isset($values[$localeSlug . 'data'])) {
+        if (isset($values[$localeSlug . 'data']) && is_array($values[$localeSlug . 'data'])) {
             $localeData = json_decode($values[$localeSlug . 'data'], true);
             foreach ($localeData as $key => $value) {
                 if ($key === 'templatefields') {


### PR DESCRIPTION
When a new record is created, the <locale>data field for non-default locales are empty. This PR avoids an exception in this case.
@SahAssar Are you OK with that?

Fixes: #89 
