### PR TITLE
Tweak the looks of the tab.

### DIFF
--- a/templates/fields/_locale.twig
+++ b/templates/fields/_locale.twig
@@ -30,7 +30,12 @@
                     <a href="{{ url(
                                 app.request.get('_route'),
                                 app.request.get('_route_params')|merge({_locale: option.get('slug') })
-                            )}}">{{ option.get('label') }}</a>
+                            )}}">
+                    {% if key == currentkey %}<strong>{% endif %}
+                    {{ option.get('label') }}
+                    {% if key == currentkey %}<em>(current)</em></strong>{% endif %}
+                </a>
+
                 </li>
             {% endfor %}
             </ul>
@@ -79,6 +84,10 @@
         padding: 5px 12px;
         line-height: 1.42857;
         margin-bottom: -1px;
+        margin-right: 12px;
+        background-color: #FDFDFA;
+        border-color: #9DABB5;
+        border-bottom: 1px solid #FDFDFA;
     }
     #locale-select button a {
         border: 0;


### PR DESCRIPTION
We've had a case where a client's translator messed up the entire DB, by replacing the correct content with the translated ones. Apparently, they got confused about which was the "current" selected language. 

This PR changes the look of the button to mimic that of an active tab, instead of a deactivated one. The pull down also makes it more clear which is the selected language. 

Before: 

![screen shot 2017-02-07 at 11 49 48](https://cloud.githubusercontent.com/assets/1833361/22688227/950e9930-ed2b-11e6-862e-a0697910008c.png)


After: 

![screen shot 2017-02-07 at 11 39 56](https://cloud.githubusercontent.com/assets/1833361/22688221/908e4978-ed2b-11e6-9d21-07b3a107897e.png)
