### PR TITLE
Fix bug in Legacy.php

### DIFF
--- a/src/Storage/Legacy.php
+++ b/src/Storage/Legacy.php
@@ -109,9 +109,10 @@ class Legacy extends Storage
 					if (isset($contentType['fields'][$key]) && $contentType['fields'][$key]['type'] === 'repeater') {
 						/**
 						* Hackish fix until #5533 gets fixed, after that the
-						* following four (4) lines can be replaced with
+						* following five (5) lines can be replaced with
 						* "$record[$key]->clear();"
 						*/
+						$originalMapping=[];
 						$originalMapping[$key]['fields'] = $contentType['fields'][$key]['fields'];
 						$originalMapping[$key]['type'] = 'repeater';
 						$mapping = $app['storage.metadata']->getRepeaterMapping($originalMapping);


### PR DESCRIPTION
When you have more than one repeater in a contenttype, it rises a FieldConfigurationException.
Initializing $originalMapping array resolves the issue.

A brief description of the Pull Request goes here.

Related:  https://github.com/bolt/bolt/issues/5533