### PR TITLE
[Bolt 3.3 Compatibility] Implement the new Field Type Interface

### DIFF
--- a/src/Field/LocaleDataField.php
+++ b/src/Field/LocaleDataField.php
@@ -3,8 +3,9 @@
 namespace Bolt\Extension\Animal\Translate\Field;
 
 use Bolt\Storage\Field\FieldInterface;
+use Bolt\Storage\Field\Type\FieldTypeBase;
 
-class LocaleDataField implements FieldInterface
+class LocaleDataField extends FieldTypeBase implements FieldInterface
 {
     public function getName()
     {

--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -3,8 +3,9 @@
 namespace Bolt\Extension\Animal\Translate\Field;
 
 use Bolt\Storage\Field\FieldInterface;
+use Bolt\Storage\Field\Type\FieldTypeBase;
 
-class LocaleField implements FieldInterface
+class LocaleField extends FieldTypeBase implements FieldInterface
 {
     public function getName()
     {


### PR DESCRIPTION
Extending FieldTypeBase in the two field classes ensures that the fields also implement FieldTypeInterface which is checked for across the Bolt 3.3 codebase.

Fixes: bolt/bolt#6840